### PR TITLE
Replace hardcoded paths with template paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ path/to/rosetta_scripts -database /path/to/rosetta_database , @flags  -parser:pr
 
 ### Database Path
 
-- `-database /share/siegellab/software/Rosetta_group_0618/main/database`: This option specifies the location of the Rosetta database, which contains necessary data for various calculations during the run.
+- `-database /path/to/rosetta_database`: This option specifies the location of the Rosetta database, which contains necessary data for various calculations during the run. You must update this to your local Rosetta installation path.
 
 ### Flags
 
@@ -50,6 +50,23 @@ path/to/rosetta_scripts -database /path/to/rosetta_database , @flags  -parser:pr
 ## Execution Environment
 
 This script is typically submitted in a high-performance computing (HPC) environment using a job scheduler like SLURM. The use of `$SLURM_ARRAY_TASK_ID` suggests that the script might be part of a job array, allowing multiple instances of the script to run simultaneously with different parameters or input files.
+
+## Path Configuration
+
+Before running the docking simulations, you need to configure the correct paths in the following files:
+
+1. **SampleData/submit.sh**:
+   - Update `/path/to/rosetta_scripts` with your Rosetta executable path
+   - Update `/path/to/rosetta_database` with your Rosetta database path
+
+2. **Output Directory**:
+   - The default output directory is set to `results/` in the submit script
+   - Ensure this directory exists or change it to your preferred output location
+
+You can find your Rosetta installation paths by:
+- Checking your Rosetta installation documentation
+- Using the command `which rosetta_scripts` if you have it in your PATH
+- Consulting your system administrator if using a shared HPC environment
 
 ## Conclusion
 

--- a/SampleData/submit.sh
+++ b/SampleData/submit.sh
@@ -1,1 +1,9 @@
-/share/siegellab/software/Rosetta_group_0618/main/source/bin/rosetta_scripts.default.linuxgccrelease -database /share/siegellab/software/Rosetta_group_0618/main/database , @flags  -parser:protocol docking.xml  -s GatZ_F6P.pdb -enzdes::cstfile 4Epimv7.cst -suffix -nstruct 1 -overwrite -suffix _$SLURM_ARRAY_TASK_ID -out:path:all test/
+#!/bin/bash
+# Replace paths below with your actual Rosetta installation paths
+/path/to/rosetta_scripts -database /path/to/rosetta_database @flags \
+  -parser:protocol docking.xml \
+  -s GatZ_F6P.pdb \
+  -enzdes::cstfile 4Epimv7.cst \
+  -suffix -nstruct 1 -overwrite \
+  -suffix _$SLURM_ARRAY_TASK_ID \
+  -out:path:all results/

--- a/docs/Submit_Script_Documentation.md
+++ b/docs/Submit_Script_Documentation.md
@@ -72,10 +72,13 @@ Modify these parameters based on your job requirements:
 ### 2. Update Paths
 
 Replace these paths with your specific locations:
-- Module load command for your HPC environment
-- Rosetta database path or environment variable
+- Module load command for your HPC environment (e.g., `module load rosetta/3.13`)
+- Rosetta executable path (either direct path or through environment variables)
+- Rosetta database path (e.g., `/path/to/rosetta_database` or `$ROSETTA_DB`)
 - Input file paths (PDB, XML, constraint files)
 - Output directory
+
+**IMPORTANT**: The provided SampleData/submit.sh script contains template paths that MUST be replaced with your actual Rosetta installation paths before running. Look for `/path/to/rosetta_scripts` and `/path/to/rosetta_database` in the script and update them accordingly.
 
 ### 3. Adjust Rosetta Parameters
 


### PR DESCRIPTION
## Summary
- Replace hardcoded Rosetta installation paths with template paths
- Add clear documentation about path configuration requirements
- Improve script formatting and readability

## Changes
- Updated submit.sh with template paths and improved formatting
- Added detailed path configuration section to README.md
- Added important note about path configuration in documentation
- Changed output directory reference from 'test/' to 'results/' for consistency

All paths that need user configuration are now clearly marked with `/path/to/...` syntax, making it easier for users to identify what needs to be changed before running the scripts.