### PR TITLE
Add ligand parameter generation script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,17 @@ This documentation provides an overview of the constraints used in a Rosetta doc
 - `CONSTRAINT::` lines define the type of constraint (distance, angle, torsion) and their parameters (ideal value, standard deviation, weight, periodicity).
 
 
+# Ligand Preparation [Documentation](docs/CalcAM1_Documentation.md)
+
+Before running docking simulations with ligands, you need to generate Rosetta parameter files. The repository includes a script that automates this process:
+
+- `examples/pre-processing/CalcAM1.py`: A Python script that prepares ligand parameters by:
+  1. Converting input files to MOL2 format
+  2. Calculating AM1-BCC charges using Antechamber
+  3. Generating Rosetta parameter files
+
+**IMPORTANT**: This script is an implementation based on the standard preprocessing protocol described in the [official Rosetta documentation](https://docs.rosettacommons.org/docs/latest/GALigandDock-Preprocessing). See the documentation for detailed usage instructions.
+
 # RosettaScripts XML [Documentation](docs/XML_Mover_Documentation.md)
 
 This XML script is designed to run a docking simulation in Rosetta, specifically focusing on the interaction between a protein and a ligand. The script utilizes various custom score functions, task operations, filters, and movers to accomplish this task. Below is a breakdown of the key components of this XML script.

--- a/docs/CalcAM1_Documentation.md
+++ b/docs/CalcAM1_Documentation.md
@@ -1,0 +1,106 @@
+# Ligand Parameter Generation with CalcAM1.py
+
+This document provides instructions for using the CalcAM1.py script, which automates the generation of Rosetta parameter files for ligands using AM1-BCC charges. **This script is an implementation based on the standard preprocessing protocol found in the [official Rosetta documentation](https://docs.rosettacommons.org/docs/latest/GALigandDock-Preprocessing).**
+
+## Overview
+
+The CalcAM1.py script performs the following steps:
+1. Converts ligand files to MOL2 format
+2. Estimates ligand charges based on chemical groups
+3. Calculates AM1-BCC charges using Antechamber
+4. Generates Rosetta parameter files using mol2genparams.py
+
+## Requirements
+
+Before using this script, ensure you have the following software installed:
+
+- Python 3.6+
+- AmberTools (for Antechamber)
+- Open Babel
+- Rosetta Software Suite
+
+## Directory Structure
+
+The script uses the following directory structure:
+
+```
+working_directory/
+├── Ligand_orig/     # Original ligand files (various formats)
+├── Ligand_mol/      # Converted MOL2 files
+├── Ligand_AM1/      # MOL2 files with AM1-BCC charges
+├── Ligand_params/   # Generated Rosetta parameter files
+└── Ligand_PDB/      # Generated PDB files
+```
+
+## Setup
+
+1. Place your ligand files in the `Ligand_orig/` directory
+2. Edit the `ParamScript` variable in CalcAM1.py to point to your Rosetta mol2genparams.py script:
+   ```python
+   ParamScript = '/path/to/rosetta/main/source/scripts/python/public/generic_potential/mol2genparams.py'
+   ```
+
+## Usage
+
+Run the script from the command line:
+
+```bash
+python CalcAM1.py
+```
+
+## How It Works
+
+### 1. File Conversion
+
+The script first converts input files to MOL2 format using Open Babel:
+
+```python
+def tomol2(fmt, molecule):
+    cmd = 'obabel -i%s %s -omol2 -O%s.mol2 -p 7.0' % (fmt, LigOrig_dir+molecule, LigMol_dir+molecule[:-4])
+    print(f"Running conversion command: {cmd}")
+    os.system(cmd)
+```
+
+### 2. Charge Estimation
+
+The script estimates molecular charges based on phosphate groups and carboxylate groups:
+
+```python
+def getcharge(molecule):
+    # Identifies phosphate groups (charge -2 each)
+    # Identifies carboxylate groups
+    # Returns estimated total charge
+```
+
+### 3. AM1-BCC Charge Calculation
+
+Antechamber is used to calculate AM1-BCC charges:
+
+```python
+def calcAM1BCC(molecule, charge):
+    # Attempts calculation with estimated charge
+    # If that fails, tries charge ± 1
+    # Generates MOL2 file with AM1-BCC charges
+```
+
+### 4. Parameter Generation
+
+Finally, Rosetta's mol2genparams.py generates parameter files:
+
+```python
+def MakeParams(molecule):
+    # Runs mol2genparams.py on the AM1-BCC MOL2 file
+    # Renames and organizes output files
+```
+
+## Troubleshooting
+
+- **Antechamber Errors**: Often related to charge issues. The script tries multiple charge states automatically.
+- **Missing Dependencies**: Ensure Antechamber, Open Babel, and Rosetta are in your PATH.
+- **File Format Issues**: Make sure input files are valid chemical structures.
+
+## References
+
+- [Rosetta GALigandDock Preprocessing Documentation](https://docs.rosettacommons.org/docs/latest/GALigandDock-Preprocessing)
+- [AM1-BCC Charge Method](https://doi.org/10.1002/jcc.10128)
+- [Antechamber Documentation](https://ambermd.org/doc12/AmberTools12.pdf)

--- a/examples/pre-processing/CalcAM1.py
+++ b/examples/pre-processing/CalcAM1.py
@@ -1,0 +1,148 @@
+import os
+import sys
+import subprocess
+import argparse
+
+# Default directory structure
+LigOrig_dir = 'Ligand_orig/'
+LigMol_dir = 'Ligand_mol/'
+LigAM1_dir = 'Ligand_AM1/'
+LigParams_dir = 'Ligand_params/'
+LigPDB_dir = 'Ligand_PDB/'
+
+# Replace with path to your Rosetta installation
+ParamScript = '/path/to/rosetta/main/source/scripts/python/public/generic_potential/mol2genparams.py'
+
+def calcAM1BCC(molecule, charge):
+    # Try both the original charge and adjusted charge to make electron count even
+    charges_to_try = [charge]
+    if charge % 2 == 0:  # if charge is even, try odd charges
+        charges_to_try.extend([charge - 1, charge + 1])
+    else:  # if charge is odd, try even charges
+        charges_to_try.extend([charge - 1, charge + 1])
+    
+    success = False
+    for try_charge in charges_to_try:
+        print(f"\nAttempting charge {try_charge} for {molecule}")
+        cmd = ('antechamber -i %s -fi mol2 -o %s.am1-bcc.mol2 -fo mol2 -c bcc -at sybyl '
+               '-nc %s -m 1 -ek "scfconv=1.d-6, ndiis_attempts=700"' % 
+               (LigMol_dir+molecule, LigAM1_dir+molecule[:-5], try_charge))
+        print(f"Running command: {cmd}")
+        result = os.system(cmd)
+        if result == 0 and os.path.exists(LigAM1_dir + molecule[:-5] + '.am1-bcc.mol2'):
+            print(f"Success with charge {try_charge}")
+            success = True
+            break
+    
+    if not success:
+        raise Exception(f"Failed to generate AM1-BCC charges for {molecule} with all attempted charges")
+
+def tomol2(fmt, molecule):
+    cmd = 'obabel -i%s %s -omol2 -O%s.mol2 -p 7.0' % (fmt, LigOrig_dir+molecule, LigMol_dir+molecule[:-4])
+    print(f"Running conversion command: {cmd}")
+    os.system(cmd)
+
+def getcharge(molecule):
+    print(f"\nCalculating charge for {molecule}")
+    with open(molecule, 'r') as mol:
+        charge = 0
+        co2 = 0
+        phosphate = 0
+        
+        for line in mol:
+            line = line.split()
+            try:
+                if len(line) > 6:
+                    if line[1] == 'P':
+                        phosphate += 1
+                        print(f"Found phosphate group: {line}")
+                        charge += -2
+                    if line[5] == 'O.co2':
+                        co2 += 1
+                        print(f"Found O.co2 group: {line}")
+            except:
+                continue
+                
+        if co2 >= 4:
+            charge += -1
+            
+        print(f"Final charge calculation:")
+        print(f"- Phosphate groups: {phosphate} (contribution: {phosphate * -2})")
+        print(f"- CO2 groups: {co2} (contribution: {-1 if co2 >= 4 else 0})")
+        print(f"- Total charge: {charge}")
+        return charge
+
+def CleanMol2(molecule):
+    print(f"\nCleaning mol2 file: {molecule}")
+    with open(molecule, 'r') as old:
+        with open(molecule+'.edit', 'w') as new:
+            write = 'yes'
+            for line in old:
+                if line.startswith('@<TRIPOS>UNITY_ATOM_ATTR'):
+                    write = 'no'
+                    print("Removing UNITY_ATOM_ATTR section")
+                if line.startswith('@<TRIPOS>BOND'):
+                    write = 'yes'
+                if write == 'yes':
+                    new.write(line)
+    os.system('mv %s.edit %s' % (molecule, molecule))
+
+def MakeParams(molecule):
+    print(f"\nGenerating parameters for {molecule}")
+    molname = molecule[:-13]
+    newmolname = molname.zfill(3)
+    
+    # Run mol2genparams
+    cmd = 'python %s -s %s' % (ParamScript, LigAM1_dir+molecule)
+    print(f"Running params generation: {cmd}")
+    result = os.system(cmd)
+    
+    if result != 0:
+        raise Exception(f"Failed to generate parameters for {molecule}")
+    
+    # Move and rename files
+    for cmd in [
+        'mv %s %s' % (molname+'.am1-bcc.params', LigParams_dir+newmolname+'.params'),
+        'mv %s %s' % (molname+'.am1-bcc_0001.pdb', LigPDB_dir+newmolname+'.pdb'),
+        "sed -i 's/%s/%s/g' %s" % ('LG1', newmolname, LigParams_dir+newmolname+'.params'),
+        "sed -i 's/%s/%s/g' %s" % ('LG1', newmolname, LigPDB_dir+newmolname+'.pdb')
+    ]:
+        print(f"Running: {cmd}")
+        os.system(cmd)
+
+def params_exist(molecule):
+    molname = os.path.splitext(molecule)[0]
+    params_file = os.path.join(LigParams_dir, f"{molname}.params")
+    exists = os.path.exists(params_file)
+    print(f"Checking for existing params: {params_file} -> {'exists' if exists else 'not found'}")
+    return exists
+
+# Create directories if they don't exist
+for directory in [LigMol_dir, LigAM1_dir, LigParams_dir, LigPDB_dir]:
+    os.makedirs(directory, exist_ok=True)
+
+# Main processing loop
+for molecule in os.listdir(LigOrig_dir):
+    try:
+        molname = os.path.splitext(molecule)[0]
+        
+        if params_exist(molecule):
+            print(f"Parameters already exist for {molecule}, skipping...")
+            continue
+            
+        print(f"\nProcessing {molecule}...")
+        tomol2(molecule[-3:], molecule)
+        
+        mol2_file = LigMol_dir + molecule[:-4] + '.mol2'
+        if not os.path.exists(mol2_file):
+            print(f"Warning: mol2 file not created: {mol2_file}")
+            continue
+            
+        charge = getcharge(mol2_file)
+        CleanMol2(mol2_file)
+        calcAM1BCC(molecule[:-4] + '.mol2', charge)
+        MakeParams(molecule[:-3] + 'am1-bcc.mol2')
+        
+    except Exception as e:
+        print(f"Error processing {molecule}: {str(e)}")
+        continue

--- a/examples/pre-processing/README.md
+++ b/examples/pre-processing/README.md
@@ -1,0 +1,34 @@
+# Ligand Preprocessing Examples
+
+This directory contains scripts for preparing ligands for Rosetta docking simulations.
+
+## CalcAM1.py
+
+A Python script that automates the generation of Rosetta parameter files for ligands by:
+1. Converting input files to MOL2 format using Open Babel
+2. Estimating molecular charges based on chemical groups
+3. Calculating AM1-BCC charges using Antechamber
+4. Generating Rosetta parameter files using mol2genparams.py
+
+**IMPORTANT**: This script is an implementation based on the standard preprocessing protocol found in the [official Rosetta documentation](https://docs.rosettacommons.org/docs/latest/GALigandDock-Preprocessing).
+
+### Usage Instructions
+
+1. Create the required directory structure:
+   ```
+   mkdir -p Ligand_orig Ligand_mol Ligand_AM1 Ligand_params Ligand_PDB
+   ```
+
+2. Place your ligand files in `Ligand_orig/`
+
+3. Edit the `ParamScript` variable in CalcAM1.py to point to your Rosetta installation:
+   ```python
+   ParamScript = '/path/to/rosetta/main/source/scripts/python/public/generic_potential/mol2genparams.py'
+   ```
+
+4. Run the script:
+   ```bash
+   python CalcAM1.py
+   ```
+
+For detailed documentation, see [Ligand Parameter Generation Documentation](../../docs/CalcAM1_Documentation.md).


### PR DESCRIPTION
## Summary
- Add CalcAM1.py script for automating ligand parameter generation
- Create comprehensive documentation for ligand preparation
- Organize examples in a dedicated directory structure

## Details
- Added CalcAM1.py to examples/pre-processing/ directory
- Created detailed documentation explaining script usage and functionality
- Updated main README.md to reference the ligand preparation process
- Added clear references to the official Rosetta GALigandDock preprocessing protocol

## Apology
We apologize for the oversight of not including the ligand parameter generation script in the original publication. This addition provides the complete workflow for preparing ligands for docking simulations with Rosetta.